### PR TITLE
Add theme toggle and update site metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# long_horizon_hierarchy
+# Long Horizon Hierarchy Project Page
+
+This repository hosts the source code for the Long Horizon Hierarchy project website. The layout is inspired by the
+[ManipGen project page](https://mihdalal.github.io/manipgen/) and provides ready-made sections for showcasing a paper,
+code, videos, architecture diagrams, and results.
+
+## Getting Started
+
+The site is served from the [`docs/`](docs/) folder so it can be published easily using GitHub Pages. To preview the page
+locally, open `docs/index.html` in your browser, or serve the folder with a simple HTTP server:
+
+```bash
+cd docs
+python -m http.server 8000
+```
+
+Then navigate to <http://localhost:8000>.
+
+## Customizing the Page
+
+Update `docs/index.html` to insert your own title, abstract, author list, teaser video, and links. The key sections are
+annotated with placeholder text so you can quickly swap in real content. Styling lives in `docs/assets/style.css`, and a
+small script for the responsive navigation bar is defined in `docs/assets/script.js`.
+
+Replace the placeholder architecture illustration stored at `docs/assets/architecture-placeholder.svg` with your own
+system diagram when you are ready.
+
+## Deploying on GitHub Pages
+
+1. Commit your changes to the `main` branch.
+2. In your repository settings, enable GitHub Pages and select the `main` branch with the `/docs` folder as the source.
+3. The site will be available at `https://<username>.github.io/<repository>/` after the deployment completes.
+
+Feel free to modify the sections or add new ones to match your project narrative.

--- a/docs/assets/architecture-placeholder.svg
+++ b/docs/assets/architecture-placeholder.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 480" role="img" aria-labelledby="title desc">
+  <title id="title">Architecture placeholder</title>
+  <desc id="desc">Simple placeholder diagram prompting the user to replace with their own system overview.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#101d38" />
+      <stop offset="100%" stop-color="#0b1324" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#7f5af0" />
+      <stop offset="100%" stop-color="#2cb1bc" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="480" fill="url(#bg)" rx="24" />
+  <rect x="70" y="160" width="180" height="110" rx="18" fill="#132649" stroke="url(#accent)" stroke-width="4" />
+  <rect x="310" y="90" width="180" height="110" rx="18" fill="#132649" stroke="url(#accent)" stroke-width="4" />
+  <rect x="310" y="270" width="180" height="110" rx="18" fill="#132649" stroke="url(#accent)" stroke-width="4" />
+  <rect x="550" y="160" width="180" height="110" rx="18" fill="#132649" stroke="url(#accent)" stroke-width="4" />
+  <text x="160" y="220" text-anchor="middle" font-family="'DM Sans', sans-serif" font-weight="600" font-size="22" fill="#f7f9fc">High-Level</text>
+  <text x="160" y="244" text-anchor="middle" font-family="'DM Sans', sans-serif" font-size="16" fill="#cbd5f5">Planner</text>
+  <text x="400" y="150" text-anchor="middle" font-family="'DM Sans', sans-serif" font-weight="600" font-size="22" fill="#f7f9fc">Skill</text>
+  <text x="400" y="174" text-anchor="middle" font-family="'DM Sans', sans-serif" font-size="16" fill="#cbd5f5">Library</text>
+  <text x="400" y="330" text-anchor="middle" font-family="'DM Sans', sans-serif" font-weight="600" font-size="22" fill="#f7f9fc">Predictive</text>
+  <text x="400" y="354" text-anchor="middle" font-family="'DM Sans', sans-serif" font-size="16" fill="#cbd5f5">Model</text>
+  <text x="640" y="220" text-anchor="middle" font-family="'DM Sans', sans-serif" font-weight="600" font-size="22" fill="#f7f9fc">Control</text>
+  <text x="640" y="244" text-anchor="middle" font-family="'DM Sans', sans-serif" font-size="16" fill="#cbd5f5">Execution</text>
+  <path d="M250 215 H300" stroke="#7f5af0" stroke-width="6" stroke-linecap="round" />
+  <path d="M490 145 H540" stroke="#7f5af0" stroke-width="6" stroke-linecap="round" />
+  <path d="M490 325 H540" stroke="#7f5af0" stroke-width="6" stroke-linecap="round" />
+  <path d="M400 200 V270" stroke="#2cb1bc" stroke-width="6" stroke-linecap="round" stroke-dasharray="12 12" />
+  <text x="400" y="430" text-anchor="middle" font-family="'DM Sans', sans-serif" font-size="18" fill="#95a3d9">Replace this SVG with your architecture.</text>
+</svg>

--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -1,0 +1,129 @@
+const toggle = document.querySelector('.menu-toggle');
+const nav = document.querySelector('.site-nav');
+const navLinks = document.querySelectorAll('.site-nav a');
+const themeToggle = document.querySelector('.theme-toggle');
+const themeToggleIcon = themeToggle ? themeToggle.querySelector('.theme-toggle__icon') : null;
+const themeToggleLabel = themeToggle ? themeToggle.querySelector('.theme-toggle__label') : null;
+const root = document.body;
+const THEME_STORAGE_KEY = 'lhh-color-theme';
+const prefersDarkScheme =
+  typeof window.matchMedia === 'function' ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+
+if (toggle) {
+  toggle.addEventListener('click', () => {
+    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!isExpanded));
+    nav.classList.toggle('is-open');
+  });
+}
+
+navLinks.forEach((link) => {
+  link.addEventListener('click', () => {
+    if (window.innerWidth <= 840) {
+      nav.classList.remove('is-open');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+  });
+});
+
+const getStoredTheme = () => {
+  try {
+    return window.localStorage.getItem(THEME_STORAGE_KEY);
+  } catch (error) {
+    return null;
+  }
+};
+
+const storeTheme = (theme) => {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch (error) {
+    // Silently ignore storage errors (e.g., private browsing).
+  }
+};
+
+const updateThemeToggle = (currentTheme) => {
+  if (!themeToggle) {
+    return;
+  }
+
+  const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+  themeToggle.setAttribute('aria-label', `Switch to ${nextTheme} mode`);
+
+  if (themeToggleIcon) {
+    themeToggleIcon.textContent = nextTheme === 'dark' ? '🌙' : '☀️';
+  }
+
+  if (themeToggleLabel) {
+    themeToggleLabel.textContent = `${nextTheme.charAt(0).toUpperCase()}${nextTheme.slice(1)} Mode`;
+  }
+};
+
+const applyTheme = (theme, { persist = true } = {}) => {
+  if (!root) {
+    return;
+  }
+
+  root.setAttribute('data-theme', theme);
+
+  if (persist) {
+    storeTheme(theme);
+  }
+
+  updateThemeToggle(theme);
+};
+
+const storedTheme = getStoredTheme();
+const systemPrefersDark = prefersDarkScheme ? prefersDarkScheme.matches : true;
+const initialTheme = storedTheme || (systemPrefersDark ? 'dark' : 'light');
+
+applyTheme(initialTheme, { persist: false });
+
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    const activeTheme = root && root.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+    applyTheme(activeTheme === 'dark' ? 'light' : 'dark');
+  });
+}
+
+if (prefersDarkScheme) {
+  const handleSystemThemeChange = (event) => {
+    if (getStoredTheme()) {
+      return;
+    }
+
+    applyTheme(event.matches ? 'dark' : 'light', { persist: false });
+  };
+
+  if (typeof prefersDarkScheme.addEventListener === 'function') {
+    prefersDarkScheme.addEventListener('change', handleSystemThemeChange);
+  } else if (typeof prefersDarkScheme.addListener === 'function') {
+    prefersDarkScheme.addListener(handleSystemThemeChange);
+  }
+}
+
+const sections = Array.from(document.querySelectorAll('main section[id]'));
+
+if ('IntersectionObserver' in window) {
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const id = entry.target.getAttribute('id');
+          navLinks.forEach((link) => {
+            if (link.getAttribute('href') === `#${id}`) {
+              link.classList.add('is-active');
+            } else {
+              link.classList.remove('is-active');
+            }
+          });
+        }
+      });
+    },
+    { threshold: 0.35 }
+  );
+
+  sections.forEach((section) => observer.observe(section));
+} else if (navLinks.length) {
+  navLinks[0].classList.add('is-active');
+}

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,603 @@
+:root {
+  --max-width: 1080px;
+  --shadow-lg: 0 24px 48px rgba(0, 0, 0, 0.35);
+  --shadow-sm: 0 8px 20px rgba(0, 0, 0, 0.25);
+  --transition-base: 150ms ease;
+  --color-accent: #7f5af0;
+  --color-accent-soft: rgba(127, 90, 240, 0.12);
+}
+
+body[data-theme="dark"] {
+  --body-bg: radial-gradient(circle at top left, #13284b 0%, #080d1a 55%, #040814 100%);
+  --color-bg: #080d1a;
+  --color-text: #f7f9fc;
+  --color-muted: rgba(247, 249, 252, 0.72);
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-header-bg: rgba(5, 10, 20, 0.75);
+  --color-hero-bg: linear-gradient(135deg, rgba(16, 27, 52, 0.85), rgba(8, 12, 24, 0.75));
+  --color-card: rgba(11, 20, 38, 0.82);
+  --color-card-alt: rgba(11, 20, 38, 0.7);
+  --color-card-soft: rgba(3, 7, 16, 0.6);
+  --color-video-bg: rgba(4, 9, 18, 0.5);
+  --color-media-placeholder-bg: rgba(7, 12, 24, 0.4);
+  --color-media-placeholder-border: rgba(255, 255, 255, 0.35);
+  --color-button-secondary-border: rgba(255, 255, 255, 0.3);
+  --color-button-secondary-hover: rgba(255, 255, 255, 0.05);
+  --color-back-to-top-border: rgba(255, 255, 255, 0.25);
+  --color-back-to-top-hover: rgba(255, 255, 255, 0.08);
+  --color-footer-bg: rgba(5, 10, 20, 0.75);
+  --color-heading: #ffffff;
+  color-scheme: dark;
+}
+
+body[data-theme="light"] {
+  --body-bg: radial-gradient(circle at top left, #ffffff 0%, #eaf0ff 55%, #d9e4ff 100%);
+  --color-bg: #f7f9ff;
+  --color-text: #0f172a;
+  --color-muted: rgba(15, 23, 42, 0.7);
+  --color-border: rgba(15, 23, 42, 0.12);
+  --color-header-bg: rgba(255, 255, 255, 0.85);
+  --color-hero-bg: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(227, 234, 255, 0.9));
+  --color-card: rgba(255, 255, 255, 0.9);
+  --color-card-alt: rgba(244, 247, 255, 0.92);
+  --color-card-soft: rgba(235, 241, 255, 0.8);
+  --color-video-bg: rgba(232, 237, 255, 0.7);
+  --color-media-placeholder-bg: rgba(233, 238, 255, 0.65);
+  --color-media-placeholder-border: rgba(15, 23, 42, 0.2);
+  --color-button-secondary-border: rgba(15, 23, 42, 0.2);
+  --color-button-secondary-hover: rgba(15, 23, 42, 0.08);
+  --color-back-to-top-border: rgba(15, 23, 42, 0.18);
+  --color-back-to-top-hover: rgba(127, 90, 240, 0.12);
+  --color-footer-bg: rgba(255, 255, 255, 0.85);
+  --color-heading: #0f172a;
+  --shadow-lg: 0 24px 48px rgba(15, 23, 42, 0.18);
+  --shadow-sm: 0 8px 20px rgba(15, 23, 42, 0.12);
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: "DM Sans", "Segoe UI", sans-serif;
+  color: var(--color-text);
+  background: var(--body-bg);
+  background-color: var(--color-bg);
+  min-height: 100vh;
+  transition: background-color 0.3s ease, color 0.3s ease, background 0.3s ease;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-accent);
+}
+
+.container {
+  width: min(92%, var(--max-width));
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 1rem min(8vw, 3rem);
+  background: var(--color-header-bg);
+  border-bottom: 1px solid var(--color-border);
+  backdrop-filter: blur(16px);
+  gap: 1.75rem;
+}
+
+.logo {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.menu-toggle {
+  display: none;
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-card);
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base), border var(--transition-base),
+    box-shadow var(--transition-base);
+  white-space: nowrap;
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 10px 24px rgba(127, 90, 240, 0.2);
+}
+
+.theme-toggle__icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.theme-toggle__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.75rem;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.site-nav a {
+  padding: 0.25rem 0;
+  position: relative;
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.35rem;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--color-accent), transparent);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 150ms ease;
+}
+
+.site-nav a:focus::after,
+.site-nav a:hover::after {
+  transform: scaleX(1);
+}
+
+.site-nav a.is-active {
+  color: var(--color-accent);
+}
+
+.site-nav a.is-active::after {
+  transform: scaleX(1);
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 4.5rem;
+  padding: 3rem 0 5rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 3rem;
+  align-items: center;
+  width: min(94%, 1200px);
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw + 1rem, 3.5rem);
+  background: var(--color-hero-bg);
+  border-radius: 24px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+}
+
+.tagline {
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.hero h1 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  margin: 1rem 0 1.25rem;
+  line-height: 1.1;
+}
+
+.hero__subtitle {
+  margin: 0 0 1.75rem;
+  color: var(--color-muted);
+  font-size: 1.05rem;
+  max-width: 36ch;
+}
+
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  background: var(--color-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 0;
+  box-shadow: var(--shadow-sm);
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.button.secondary {
+  background: transparent;
+  border: 1px solid var(--color-button-secondary-border);
+  color: var(--color-text);
+  box-shadow: none;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(127, 90, 240, 0.35);
+}
+
+.button.secondary:hover,
+.button.secondary:focus {
+  background: var(--color-button-secondary-hover);
+}
+
+.hero__meta {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.authors span {
+  margin-inline-start: 0.4rem;
+}
+
+.hero__visual {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  background: var(--color-video-bg);
+  box-shadow: var(--shadow-sm);
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.video-caption {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.section-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+.section-header h2 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 2rem;
+  margin: 0;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--color-muted);
+  max-width: 50ch;
+}
+
+.highlights {
+  margin-top: 1rem;
+}
+
+.highlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.highlight-card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  padding: 1.5rem;
+  border-radius: 18px;
+  box-shadow: var(--shadow-sm);
+}
+
+.highlight-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-family: "Space Grotesk", sans-serif;
+}
+
+.highlight-card p {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.abstract {
+  background: var(--color-card-soft);
+  padding: 3rem 0;
+  border-block: 1px solid var(--color-border);
+}
+
+.abstract p {
+  max-width: 80ch;
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.architecture {
+  padding: 3rem 0;
+}
+
+.architecture__content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.architecture img {
+  width: 100%;
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  background: var(--color-card-alt);
+  box-shadow: var(--shadow-sm);
+}
+
+.architecture__text {
+  background: var(--color-card-alt);
+  padding: 1.75rem;
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  color: var(--color-muted);
+}
+
+.architecture__text h3 {
+  margin-top: 0;
+  color: var(--color-heading);
+}
+
+.architecture__text ul {
+  padding-left: 1.2rem;
+}
+
+.architecture__text li {
+  margin-bottom: 0.5rem;
+}
+
+.results {
+  padding: 3rem 0;
+}
+
+.result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+}
+
+.result-card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1rem;
+}
+
+.media-placeholder {
+  height: 180px;
+  border: 1px dashed var(--color-media-placeholder-border);
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  color: var(--color-muted);
+  background: var(--color-media-placeholder-bg);
+  text-align: center;
+  padding: 0 1rem;
+}
+
+.result-card h3 {
+  margin: 0;
+  font-family: "Space Grotesk", sans-serif;
+}
+
+.result-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.resources {
+  padding: 3rem 0;
+  background: var(--color-card-soft);
+  border-block: 1px solid var(--color-border);
+}
+
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.resource-card {
+  background: var(--color-card);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 1.75rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.resource-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.bibtex {
+  padding: 3rem 0 1rem;
+}
+
+.bibtex pre {
+  background: var(--color-card-alt);
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  overflow-x: auto;
+  line-height: 1.6;
+}
+
+.site-footer {
+  padding: 2.5rem 0 3rem;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-footer-bg);
+}
+
+.site-footer p {
+  margin: 0 0 0.75rem;
+  color: var(--color-muted);
+  text-align: center;
+}
+
+.back-to-top {
+  display: inline-block;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-back-to-top-border);
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  transition: background var(--transition-base);
+  text-align: center;
+}
+
+.back-to-top:hover,
+.back-to-top:focus {
+  background: var(--color-back-to-top-hover);
+}
+
+@media (max-width: 840px) {
+  .site-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .header-controls {
+    width: 100%;
+    justify-content: flex-end;
+    margin-left: 0;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .site-nav {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.85rem;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 200ms ease;
+  }
+
+  .site-nav.is-open {
+    max-height: 400px;
+    padding-top: 0.5rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 2rem 1.25rem;
+  }
+
+  .hero__subtitle {
+    max-width: unset;
+  }
+
+  main {
+    gap: 3.5rem;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Project page for Hierarchical VLM-RL Long Horizon Manipulation."
+    />
+    <title>Hierarchical VLM-RL Long Horizon Manipulation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Space+Grotesk:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/style.css" />
+    <script defer src="assets/script.js"></script>
+  </head>
+  <body data-theme="dark">
+    <header class="site-header" id="top">
+      <div class="logo">Hierarchical VLM-RL Long Horizon Manipulation</div>
+      <div class="header-controls">
+        <button class="theme-toggle" type="button" aria-label="Switch to light mode">
+          <span class="theme-toggle__icon" aria-hidden="true">☀️</span>
+          <span class="theme-toggle__label">Light Mode</span>
+        </button>
+        <button class="menu-toggle" aria-expanded="false" aria-controls="site-nav">Menu</button>
+      </div>
+      <nav id="site-nav" class="site-nav" aria-label="Main navigation">
+        <a href="#overview">Overview</a>
+        <a href="#abstract">Abstract</a>
+        <a href="#architecture">Architecture</a>
+        <a href="#results">Results</a>
+        <a href="#resources">Resources</a>
+        <a href="#bibtex">BibTeX</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero" id="overview">
+        <div class="hero__content">
+          <p class="tagline">Project Overview</p>
+          <h1>Hierarchical VLM-RL Long Horizon Manipulation</h1>
+          <p class="hero__subtitle">
+            Replace this paragraph with a concise one-sentence pitch for the project. The styling matches the ManipGen
+            page so you can quickly drop in your own description while showcasing hierarchical VLM-RL manipulation.
+          </p>
+          <div class="hero__cta">
+            <a class="button" href="#" target="_blank" rel="noopener">Paper</a>
+            <a class="button" href="#" target="_blank" rel="noopener">Code</a>
+            <a class="button" href="#" target="_blank" rel="noopener">Video</a>
+            <a class="button" href="#" target="_blank" rel="noopener">Summary</a>
+          </div>
+          <div class="hero__meta">
+            <p class="authors">
+              <strong>Authors:</strong>
+              <span>Puru Ojha</span>
+              <span>and Narendhiran Vijayakumar</span>
+            </p>
+            <p class="publication">Conference or workshop information goes here.</p>
+          </div>
+        </div>
+        <div class="hero__visual">
+          <div class="video-wrapper">
+            <iframe
+              src="https://www.youtube.com/embed/videocode"
+              title="Project teaser"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
+          </div>
+          <p class="video-caption">Embed a teaser or system overview video.</p>
+        </div>
+      </section>
+
+      <section class="highlights" aria-label="Project highlights">
+        <div class="container">
+          <h2>Key Contributions</h2>
+          <div class="highlight-grid">
+            <article class="highlight-card">
+              <h3>Long-Horizon Planning</h3>
+              <p>Summarize a major research insight or capability.</p>
+            </article>
+            <article class="highlight-card">
+              <h3>Hierarchical Policies</h3>
+              <p>Explain how the hierarchy or abstraction improves performance.</p>
+            </article>
+            <article class="highlight-card">
+              <h3>Open-Source Release</h3>
+              <p>Call out datasets, simulators, or training code that will be released.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="abstract" class="abstract">
+        <div class="container">
+          <h2>Abstract</h2>
+          <p>
+            This section mirrors the layout of the ManipGen page while keeping the copy lightweight so that you can paste
+            in the official abstract from your paper. Use <strong>&lt;br&gt;</strong> tags to insert intentional line
+            breaks if necessary.
+          </p>
+        </div>
+      </section>
+
+      <section id="architecture" class="architecture">
+        <div class="container">
+          <div class="section-header">
+            <h2>Architecture</h2>
+            <p>Showcase the hierarchical components and data flow used in the project.</p>
+          </div>
+          <div class="architecture__content">
+            <img
+              src="assets/architecture-placeholder.svg"
+              alt="Placeholder diagram. Replace with your architecture graphic."
+            />
+            <div class="architecture__text">
+              <h3>How it Works</h3>
+              <p>
+                Provide a succinct explanation of the system diagram shown to the left. You can elaborate on the stages,
+                controllers, or modules used in your method. Keep the copy short and scannable.
+              </p>
+              <ul>
+                <li>Bullet point key components.</li>
+                <li>Explain any interesting implementation details.</li>
+                <li>Link to supplementary material where relevant.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="results" class="results">
+        <div class="container">
+          <div class="section-header">
+            <h2>Results</h2>
+            <p>Drop in qualitative rollouts, comparisons, or interactive sliders.</p>
+          </div>
+          <div class="result-grid">
+            <article class="result-card">
+              <div class="media-placeholder">
+                <p>Add animated GIFs or MP4 rollouts.</p>
+              </div>
+              <h3>Simulation</h3>
+              <p>Describe key takeaways from simulation experiments.</p>
+            </article>
+            <article class="result-card">
+              <div class="media-placeholder">
+                <p>Insert side-by-side comparisons.</p>
+              </div>
+              <h3>Real Robot</h3>
+              <p>Outline performance on hardware or real-world evaluation.</p>
+            </article>
+            <article class="result-card">
+              <div class="media-placeholder">
+                <p>Use this card for ablations or other highlights.</p>
+              </div>
+              <h3>Ablations</h3>
+              <p>Mention what each analysis reveals.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="resources" class="resources">
+        <div class="container">
+          <h2>Resources</h2>
+          <div class="resource-grid">
+            <article class="resource-card">
+              <h3>Paper</h3>
+              <p>Link to the arXiv or conference version.</p>
+              <a class="button secondary" href="#" target="_blank" rel="noopener">Read the Paper</a>
+            </article>
+            <article class="resource-card">
+              <h3>Code</h3>
+              <p>Point to the repository or release branch.</p>
+              <a class="button secondary" href="#" target="_blank" rel="noopener">Browse Code</a>
+            </article>
+            <article class="resource-card">
+              <h3>Dataset</h3>
+              <p>Include dataset download links or documentation.</p>
+              <a class="button secondary" href="#" target="_blank" rel="noopener">Get Data</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="bibtex" class="bibtex">
+        <div class="container">
+          <h2>BibTeX</h2>
+          <pre>
+@inproceedings{long2025hierarchy,
+  title     = {Hierarchical Planning for Long-Horizon Video Manipulation},
+  author    = {Replace and With and Your Own Names},
+  booktitle = {Conference on Robotics and Automation},
+  year      = {2025}
+}
+          </pre>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>
+          Built with a lightweight template inspired by
+          <a href="https://mihdalal.github.io/manipgen/" target="_blank" rel="noopener">ManipGen</a>. Replace this text
+          with acknowledgements or contact information.
+        </p>
+        <a class="back-to-top" href="#top">Back to top ↑</a>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a light/dark theme toggle with preference persistence and system color scheme support
- update the site title and hero content for Hierarchical VLM-RL Long Horizon Manipulation by Puru Ojha and Narendhiran Vijayakumar
- refactor styling variables so components render appropriately across both color themes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca891c51d8832c9f3e9b05e499a73f