### PR TITLE
Rebuild site using BestMan-inspired layout

### DIFF
--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -1,199 +1,56 @@
-// scripts for Long Horizon Hierarchy project page
-// Merged and conflict-free: combines theme toggle, responsive nav, and active-section highlighting.
+(function () {
+  function initNavbar() {
+    var burger = document.querySelector('.navbar-burger');
+    var menu = document.getElementById(burger && burger.dataset.target);
+    if (!burger || !menu) return;
 
-const root = document.body;
+    burger.addEventListener('click', function () {
+      var active = burger.classList.toggle('is-active');
+      menu.classList.toggle('is-active', active);
+      burger.setAttribute('aria-expanded', active ? 'true' : 'false');
+    });
 
-// --- NAV ELEMENTS (support both data-js and legacy class selectors) ---
-const nav =
-  document.querySelector('[data-js="site-nav"]') ||
-  document.querySelector('.site-nav');
-
-const navLinks = nav
-  ? Array.from(nav.querySelectorAll('a[href^="#"]'))
-  : Array.from(document.querySelectorAll('.site-nav a[href^="#"]'));
-
-// Menu toggle button (hamburger)
-const menuToggle =
-  document.querySelector('[data-js="menu-toggle"]') ||
-  document.querySelector('.menu-toggle');
-
-// Theme toggle button (optional)
-const themeToggle =
-  document.querySelector('[data-js="theme-toggle"]') ||
-  document.querySelector('.theme-toggle');
-
-const themeToggleIcon = themeToggle
-  ? themeToggle.querySelector('.theme-toggle__icon')
-  : null;
-
-const themeToggleText = themeToggle
-  ? themeToggle.querySelector('.theme-toggle__text')
-  : null;
-
-// --- THEME HANDLING ---
-const THEME_STORAGE_KEY = 'lhh-color-theme';
-const prefersDark =
-  typeof window.matchMedia === 'function'
-    ? window.matchMedia('(prefers-color-scheme: dark)')
-    : null;
-
-const getStoredTheme = () => {
-  try {
-    return window.localStorage.getItem(THEME_STORAGE_KEY);
-  } catch {
-    return null;
+    menu.querySelectorAll('a[href^="#"]').forEach(function (link) {
+      link.addEventListener('click', function () {
+        if (burger.classList.contains('is-active')) {
+          burger.classList.remove('is-active');
+          menu.classList.remove('is-active');
+          burger.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
   }
-};
 
-const storeTheme = (theme) => {
-  try {
-    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
-  } catch {
-    // Ignore storage errors (e.g., private browsing)
-  }
-};
+  function initTabs() {
+    document.querySelectorAll('[data-tabs]').forEach(function (tabs) {
+      var tabLinks = tabs.querySelectorAll('li');
+      tabLinks.forEach(function (tab) {
+        tab.addEventListener('click', function (event) {
+          event.preventDefault();
+          if (tab.classList.contains('is-active')) return;
 
-const updateThemeToggle = (currentTheme) => {
-  if (!themeToggle) return;
+          var target = tab.querySelector('a').getAttribute('href');
+          var container = tabs.nextElementSibling;
 
-  const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
-  const label = `Switch to ${nextTheme} theme`;
+          tabLinks.forEach(function (item) {
+            item.classList.remove('is-active');
+          });
+          tab.classList.add('is-active');
 
-  themeToggle.setAttribute('aria-label', label);
-  themeToggle.setAttribute('title', label);
-
-  if (themeToggleIcon) {
-    themeToggleIcon.textContent = nextTheme === 'dark' ? '🌙' : '☀️';
-  }
-  if (themeToggleText) {
-    themeToggleText.textContent =
-      `${nextTheme.charAt(0).toUpperCase()}${nextTheme.slice(1)} Mode`;
-  }
-};
-
-const applyTheme = (theme, { persist = true } = {}) => {
-  if (!root) return;
-  root.setAttribute('data-theme', theme);
-  if (persist) storeTheme(theme);
-  updateThemeToggle(theme);
-};
-
-const storedTheme = getStoredTheme();
-const systemPrefersDark = prefersDark ? prefersDark.matches : true;
-const initialTheme = storedTheme || (systemPrefersDark ? 'dark' : 'light');
-applyTheme(initialTheme, { persist: false });
-
-if (themeToggle) {
-  themeToggle.addEventListener('click', () => {
-    const activeTheme =
-      root.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
-    applyTheme(activeTheme === 'dark' ? 'light' : 'dark');
-  });
-}
-
-if (prefersDark) {
-  const handleSystemThemeChange = (event) => {
-    // Respect explicit user choice in localStorage
-    if (getStoredTheme()) return;
-    applyTheme(event.matches ? 'dark' : 'light', { persist: false });
-  };
-
-  if (typeof prefersDark.addEventListener === 'function') {
-    prefersDark.addEventListener('change', handleSystemThemeChange);
-  } else if (typeof prefersDark.addListener === 'function') {
-    // Safari < 14
-    prefersDark.addListener(handleSystemThemeChange);
-  }
-}
-
-// --- RESPONSIVE NAV / MENU ---
-if (menuToggle && nav) {
-  menuToggle.addEventListener('click', () => {
-    const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
-    menuToggle.setAttribute('aria-expanded', String(!isExpanded));
-    nav.classList.toggle('is-open');
-  });
-
-  // Close nav when clicking outside
-  document.addEventListener('click', (event) => {
-    if (!nav.classList.contains('is-open')) return;
-    const target = event.target;
-    if (target === nav || nav.contains(target) || menuToggle.contains(target)) {
-      return;
-    }
-    nav.classList.remove('is-open');
-    menuToggle.setAttribute('aria-expanded', 'false');
-  });
-
-  // Close with Escape
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && nav.classList.contains('is-open')) {
-      nav.classList.remove('is-open');
-      menuToggle.setAttribute('aria-expanded', 'false');
-      menuToggle.focus();
-    }
-  });
-
-  // Close on resize to desktop
-  window.addEventListener('resize', () => {
-    if (window.innerWidth > 960 && nav.classList.contains('is-open')) {
-      nav.classList.remove('is-open');
-      menuToggle.setAttribute('aria-expanded', 'false');
-    }
-  });
-}
-
-// Close the nav after clicking a link (mobile)
-navLinks.forEach((link) => {
-  link.addEventListener('click', () => {
-    if (!nav) return;
-    if (window.innerWidth <= 960 && nav.classList.contains('is-open')) {
-      nav.classList.remove('is-open');
-      if (menuToggle) {
-        menuToggle.setAttribute('aria-expanded', 'false');
-      }
-    }
-  });
-});
-
-// --- ACTIVE SECTION HIGHLIGHTING ---
-/**
- * Prefer sections that nav links point to.
- * Fallback: any <main> section with an id.
- */
-let sections = navLinks
-  .map((link) => {
-    const targetId = link.getAttribute('href');
-    if (!targetId || !targetId.startsWith('#')) return null;
-    return document.querySelector(targetId);
-  })
-  .filter(Boolean);
-
-// Fallback if no sections resolvable from navLinks
-if (!sections.length) {
-  sections = Array.from(document.querySelectorAll('main section[id]'));
-}
-
-if ('IntersectionObserver' in window && sections.length) {
-  const observer = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (!entry.isIntersecting) return;
-        const id = entry.target.getAttribute('id');
-        navLinks.forEach((link) => {
-          if (link.getAttribute('href') === `#${id}`) {
-            link.classList.add('is-active');
-          } else {
-            link.classList.remove('is-active');
+          container.querySelectorAll('.tab-pane').forEach(function (pane) {
+            pane.classList.remove('is-active');
+          });
+          var activePane = container.querySelector(target);
+          if (activePane) {
+            activePane.classList.add('is-active');
           }
         });
       });
-    },
-    { threshold: 0.4 }
-  );
+    });
+  }
 
-  sections.forEach((section) => observer.observe(section));
-} else if (navLinks.length) {
-  // Basic fallback: mark the first link active
-  navLinks[0].classList.add('is-active');
-}
+  document.addEventListener('DOMContentLoaded', function () {
+    initNavbar();
+    initTabs();
+  });
+})();

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,896 +1,160 @@
-/* Long Horizon Hierarchy – merged, conflict-free stylesheet */
-/* Combines themeable variables, responsive nav, hero, highlights, results, resources, bibtex, and footer. */
-
-/* ============================= */
-/* Root variables & base theming */
-/* ============================= */
 :root {
-  /* Layout */
-  --container-width: 1200px;
-  --max-width: 1080px;
-
-  /* Typography */
-  --font-body: "DM Sans", "Google Sans", "Segoe UI", sans-serif;
-  --font-display: "Space Grotesk", "Google Sans", "Segoe UI", sans-serif;
-
-  /* Motion & shape */
-  --transition: 200ms ease;
-  --radius-lg: 20px;
-
-  /* Shadows (both naming schemes supported) */
-  --shadow-elevated: 0 24px 55px rgba(7, 11, 25, 0.35);
-  --shadow-soft: 0 18px 40px rgba(7, 11, 25, 0.2);
-  --shadow-lg: 0 24px 48px rgba(0, 0, 0, 0.35);
-  --shadow-sm: 0 8px 20px rgba(0, 0, 0, 0.25);
-}
-
-/* Dark theme variables */
-body[data-theme="dark"] {
-  --color-bg: #050913;
-  --color-surface: rgba(12, 18, 36, 0.88);
-  --color-surface-alt: rgba(12, 20, 40, 0.7);
-  --color-section: rgba(6, 12, 28, 0.62);
-  --color-border: rgba(255, 255, 255, 0.08);
-  --color-text: #edf1ff;
-  --color-heading: #ffffff;
-  --color-muted: rgba(218, 227, 255, 0.75);
-  --color-accent: #7b83ff;
-  --color-accent-strong: #8f7bff;
-  --color-accent-soft: rgba(123, 131, 255, 0.14);
-  --color-hero-gradient: radial-gradient(circle at 10% 10%, #25356d 0%, #0c142a 46%, #050913 100%);
-  --color-header: rgba(6, 12, 26, 0.85);
-  --color-outline: rgba(123, 131, 255, 0.28);
-  --color-button-text: #ffffff;
-  --color-footer-bg: rgba(6, 12, 26, 0.92);
-  /* Extras used by legacy rules */
-  --color-card: #0f1c33;
-  color-scheme: dark;
-}
-
-/* Light theme variables */
-body[data-theme="light"] {
-  --color-bg: #f4f6ff;
-  --color-surface: rgba(255, 255, 255, 0.9);
-  --color-surface-alt: #eef2ff;
-  --color-section: rgba(228, 234, 255, 0.65);
-  --color-border: rgba(17, 24, 39, 0.12);
-  --color-text: #15213c;
-  --color-heading: #0b1120;
-  --color-muted: rgba(71, 85, 105, 0.8);
-  --color-accent: #4c51bf;
-  --color-accent-strong: #312e81;
-  --color-accent-soft: rgba(76, 81, 191, 0.12);
-  --color-hero-gradient: radial-gradient(circle at 5% 25%, #ffffff 0%, #eef2ff 48%, #e0e7ff 100%);
-  --color-header: rgba(255, 255, 255, 0.88);
-  --color-outline: rgba(76, 81, 191, 0.28);
-  --color-button-text: #ffffff;
-  --color-footer-bg: rgba(235, 240, 255, 0.85);
-  /* Override shadows for light */
-  --shadow-elevated: 0 28px 48px rgba(15, 23, 42, 0.16);
-  --shadow-soft: 0 18px 38px rgba(15, 23, 42, 0.12);
-  --color-card: #ffffff;
-  color-scheme: light;
-}
-
-/* ================= */
-/* Global resets     */
-/* ================= */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-html {
-  scroll-behavior: smooth;
+  --primary: #1a56db;
+  --primary-dark: #0f2d6b;
+  --accent: #f97316;
+  --bg-light: #f5f7fb;
+  --text-dark: #0f172a;
+  --text-muted: #4b5563;
+  --border-color: rgba(15, 23, 42, 0.1);
+  font-size: 16px;
 }
 
 body {
-  margin: 0;
-  font-family: var(--font-body);
-  background: var(--color-bg);
-  background-color: var(--color-bg);
-  color: var(--color-text);
-  min-height: 100vh;
-  line-height: 1.6;
-  transition: background 0.35s ease, color 0.35s ease;
+  font-family: "Google Sans", "Segoe UI", sans-serif;
+  color: var(--text-dark);
+  background: white;
 }
 
-main {
-  display: flex;
-  flex-direction: column;
-  gap: 4.5rem;
-  padding: 3rem 0 5rem;
+.navbar {
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.05);
 }
 
-main section {
-  scroll-margin-top: 96px;
+.navbar .logo {
+  font-family: "Castoro", serif;
+  font-size: 1.25rem;
+  font-weight: 700;
 }
 
-p {
-  margin: 0 0 1rem;
-}
-
-ul {
-  margin: 0 0 1.25rem;
-  padding-left: 1.25rem;
-}
-
-li {
-  margin-bottom: 0.6rem;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-  transition: color var(--transition), opacity var(--transition);
-}
-
-a:hover,
-a:focus,
-a:focus-visible {
-  color: var(--color-accent);
-}
-
-img,
-video {
-  display: block;
-  max-width: 100%;
-}
-
-iframe {
-  border: 0;
-}
-
-/* ================= */
-/* Layout helpers    */
-/* ================= */
-.container {
-  width: min(92%, var(--container-width));
-  margin: 0 auto;
-}
-
-section {
-  padding: clamp(3rem, 6vw, 5.5rem) 0;
-}
-
-.section-title {
-  font-family: var(--font-display);
-  font-size: clamp(2rem, 5vw, 3rem);
-  margin: 0 0 0.5rem;
-  color: var(--color-heading);
-  text-align: center;
-}
-
-.section-subtitle {
-  font-size: 1.05rem;
-  color: var(--color-muted);
-  max-width: 720px;
-  margin: 0 auto clamp(2rem, 5vw, 3rem);
-  text-align: center;
-}
-
-/* ================= */
-/* Buttons           */
-/* ================= */
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  padding: 0.6rem 1.2rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: var(--color-accent);
-  color: var(--color-button-text);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition),
-    background var(--transition);
-  box-shadow: var(--shadow-sm);
-}
-
-.button .icon {
-  font-size: 1.05rem;
-  line-height: 1;
-}
-
-.button:hover,
-.button:focus,
-.button:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 14px 32px rgba(123, 131, 255, 0.35);
-}
-
-.button.secondary {
+.navbar-item:hover,
+.navbar-item:focus {
   background: transparent;
-  border-color: var(--color-border);
-  color: var(--color-heading);
-  box-shadow: none;
+  color: var(--primary);
 }
 
-.button.secondary:hover,
-.button.secondary:focus,
-.button.secondary:focus-visible {
-  border-color: var(--color-accent);
-  color: var(--color-heading);
-  box-shadow: 0 12px 28px rgba(123, 131, 255, 0.24);
-}
-
-/* ================= */
-/* Header & Nav      */
-/* ================= */
-.site-header {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  background: var(--color-header);
-  border-bottom: 1px solid var(--color-border);
-  backdrop-filter: blur(18px);
-}
-
-.site-header__inner {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  padding: 0.9rem 0;
-  position: relative;
-}
-
-.site-logo,
-.logo {
-  font-family: var(--font-display);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.9rem;
-  color: var(--color-heading);
-}
-
-.menu-toggle {
-  display: none;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.45rem 0.95rem;
-  border-radius: 999px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface);
-  color: var(--color-heading);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: border-color var(--transition), background var(--transition), color var(--transition);
-}
-
-.menu-toggle:hover,
-.menu-toggle:focus-visible {
-  border-color: var(--color-accent);
-  color: var(--color-heading);
-}
-
-.theme-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  margin-left: 1rem;
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface);
-  color: var(--color-heading);
-  font-weight: 600;
-  font-size: 0.85rem;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: border-color var(--transition), background var(--transition), color var(--transition),
-    box-shadow var(--transition);
-}
-
-.theme-toggle:hover,
-.theme-toggle:focus-visible {
-  border-color: var(--color-accent);
-  box-shadow: 0 12px 32px rgba(123, 131, 255, 0.22);
-}
-
-.theme-toggle__icon {
-  font-size: 1rem;
-  line-height: 1;
-}
-
-.site-nav {
-  display: flex;
-  align-items: center;
-  gap: 1.75rem;
-  margin-left: auto;
-  font-size: 0.95rem;
-}
-
-.site-nav a {
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  font-size: 0.92rem;
-  color: var(--color-muted);
-  padding: 0.25rem 0;
-  position: relative;
-}
-
-.site-nav a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -0.4rem;
-  width: 100%;
-  height: 2px;
-  border-radius: 1px;
-  background: linear-gradient(90deg, transparent, var(--color-accent), transparent);
-  transform: scaleX(0);
-  transform-origin: center;
-  transition: transform 160ms ease;
-}
-
-.site-nav a:hover::after,
-.site-nav a:focus-visible::after,
-.site-nav a.is-active::after {
-  transform: scaleX(1);
-}
-
-.site-nav a.is-active {
-  color: var(--color-heading);
-}
-
-/* ============ */
-/* Hero section */
-/* ============ */
 .hero {
-  background: var(--color-hero-gradient);
-  padding-top: clamp(4rem, 8vw, 6.5rem);
-  padding-bottom: clamp(4rem, 8vw, 6.5rem);
-  border-bottom: 1px solid var(--color-border);
+  padding-top: 3rem;
+  padding-bottom: 3rem;
 }
 
-.hero__inner {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(2.5rem, 6vw, 4.5rem);
-  align-items: center;
+.hero .subtitle {
+  color: var(--text-muted);
 }
 
-.hero__eyebrow,
-.tagline {
-  display: inline-block;
-  font-size: 0.85rem;
-  letter-spacing: 0.28em;
-  text-transform: uppercase;
-  color: var(--color-accent);
-  background: var(--color-accent-soft);
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  font-weight: 600;
+.buttons .button {
+  margin-right: 0.75rem;
 }
 
-.hero__title,
-.hero h1 {
-  font-family: var(--font-display);
-  font-size: clamp(2.6rem, 6vw, 3.8rem);
-  margin: 1rem 0 1.25rem;
-  color: var(--color-heading);
-  line-height: 1.12;
-}
-
-.hero__lead,
-.hero__subtitle {
-  font-size: 1.1rem;
-  color: var(--color-muted);
-  margin: 1.5rem 0 2rem;
-  max-width: 36ch;
-}
-
-.hero__meta {
-  display: grid;
-  gap: 0.5rem;
-  color: var(--color-muted);
-  font-size: 0.98rem;
-}
-
-.hero__authors,
-.authors span {
-  color: var(--color-heading);
-  font-weight: 600;
-  margin-inline-start: 0.4rem;
-}
-
-.hero__media,
-.hero__visual {
-  display: grid;
-  gap: 1rem;
-}
-
-/* Video containers (both naming schemes) */
-.video-frame,
 .video-wrapper {
   position: relative;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  border-radius: 20px;
+  padding-bottom: 56.25%;
+  height: 0;
   overflow: hidden;
-  background: var(--color-section);
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-elevated);
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
 }
 
-.video-wrapper {
-  padding-bottom: 0; /* ensure aspect-ratio governs */
-  height: auto;
-}
-
-.video-frame iframe,
 .video-wrapper iframe {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
-  border: 0;
+  border-radius: 18px;
 }
 
-.video-caption {
-  font-size: 0.9rem;
-  color: var(--color-muted);
+.section.is-light {
+  background: var(--bg-light);
 }
 
-/* ============ */
-/* Teaser strip */
-/* ============ */
-.teaser {
-  background: var(--color-section);
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
+.highlight,
+.result-card,
+.resource-card {
+  border-radius: 20px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+  padding: 2rem;
+  height: 100%;
 }
 
-.teaser .video-frame {
-  max-width: 960px;
-  margin: 0 auto;
+.highlight h3,
+.result-card h3,
+.resource-card h3 {
+  margin-bottom: 0.75rem;
 }
 
-/* ================== */
-/* Section header row */
-/* ================== */
-.section-header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 2rem;
-  margin-bottom: 2rem;
+#hierarchy .tabs {
+  margin-top: 3rem;
 }
 
-.section-header h2 {
-  font-family: var(--font-display);
-  font-size: 2rem;
-  margin: 0;
+.tabs ul {
+  border: none;
 }
 
-.section-header p {
-  margin: 0;
-  color: var(--color-muted);
-  max-width: 50ch;
+.tabs li.is-active a {
+  background: var(--primary);
+  color: #fff;
 }
 
-/* ===================== */
-/* Highlights & Abstract */
-/* ===================== */
-.highlights {
+.tabs a {
+  border-radius: 999px !important;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+}
+
+.tab-content {
   margin-top: 1rem;
 }
 
-.highlight-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
+.tab-pane {
+  display: none;
 }
 
-.highlight-card {
-  padding: 1.75rem;
-  border-radius: var(--radius-lg);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-soft);
-  display: grid;
-  gap: 0.75rem;
+.tab-pane.is-active {
+  display: block;
 }
 
-.highlight-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.highlight-card p {
-  margin: 0;
-  color: var(--color-muted);
-}
-
-.abstract {
-  background: rgba(3, 7, 16, 0.6);
-  padding: 3rem 0;
-  border-block: 1px solid var(--color-border);
-}
-
-.abstract .content,
-.abstract p {
-  max-width: 780px;
-  margin: 0 auto;
-  font-size: 1.05rem;
-  color: var(--color-muted);
-  line-height: 1.6;
-}
-
-/* =============== */
-/* Architecture UI */
-/* =============== */
-.architecture {
-  background: var(--color-section);
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.architecture__grid,
-.architecture__content {
-  display: grid;
-  gap: clamp(2rem, 5vw, 3.5rem);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  align-items: center;
-}
-
-.architecture img {
+.tab-pane video {
   width: 100%;
-  border-radius: 20px;
-  border: 1px solid var(--color-border);
-  background: rgba(8, 12, 24, 0.7);
-  box-shadow: var(--shadow-sm);
+  height: auto;
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
+  border-radius: 18px;
 }
 
-.architecture__text {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: clamp(1.5rem, 4vw, 2rem);
-  box-shadow: var(--shadow-soft);
-  color: var(--color-muted);
+.table thead th {
+  background: var(--primary);
+  color: #fff;
 }
 
-.architecture__text h3 {
-  margin-top: 0;
-  color: var(--color-heading);
-  font-family: var(--font-display);
+.table tbody td {
+  vertical-align: top;
 }
 
-.architecture__text ul {
-  color: var(--color-muted);
-  padding-left: 1.2rem;
+.footer {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem 0;
 }
 
-.architecture__text li {
-  margin-bottom: 0.5rem;
+.footer a {
+  color: #e2e8f0;
+  text-decoration: underline;
 }
 
-/* ============ */
-/* Results area */
-/* ============ */
-.results {
-  padding: 3rem 0;
+.footer a:hover {
+  color: var(--accent);
 }
 
-.results__grid,
-.result-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.result-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 1.25rem;
-  display: grid;
-  gap: 1rem;
-  box-shadow: var(--shadow-soft);
-}
-
-.result-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.result-card p {
-  margin: 0;
-  color: var(--color-muted);
-}
-
-.media-placeholder {
-  display: grid;
-  place-items: center;
-  aspect-ratio: 16 / 9;
-  border-radius: 16px;
-  background: var(--color-section);
-  border: 1px dashed var(--color-border);
-  color: var(--color-muted);
-  font-size: 0.9rem;
-  text-align: center;
-  padding: 0.75rem;
-}
-
-/* ================== */
-/* Long-horizon cards */
-/* ================== */
-.long-horizon {
-  background: var(--color-section);
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.long-horizon__grid {
-  display: grid;
-  gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.long-horizon-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 1.1rem;
-  display: grid;
-  gap: 0.75rem;
-  box-shadow: var(--shadow-soft);
-}
-
-.long-horizon-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.long-horizon-card p {
-  margin: 0;
-  color: var(--color-muted);
-}
-
-/* ================ */
-/* Resources & Bib  */
-/* ================ */
-.resources {
-  padding: 3rem 0;
-  background: rgba(3, 7, 16, 0.6);
-  border-block: 1px solid var(--color-border);
-}
-
-.resources .section-subtitle {
-  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
-}
-
-.resource-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.resource-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 1.75rem;
-  display: grid;
-  gap: 1rem;
-  box-shadow: var(--shadow-soft);
-}
-
-.resource-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.resource-card p {
-  margin: 0;
-  color: var(--color-muted);
-}
-
-.resource-card .button {
-  justify-content: center;
-  margin-top: 0.5rem;
-}
-
-.bibtex {
-  padding: 3rem 0 1rem;
-}
-
-.bibtex pre {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  padding: 1.5rem;
-  overflow-x: auto;
-  font-size: 0.95rem;
-  line-height: 1.55;
-  color: var(--color-muted);
-  box-shadow: var(--shadow-soft);
-}
-
-code,
-pre,
-pre code {
-  font-family: "DM Mono", "SFMono-Regular", Menlo, Consolas, monospace;
-}
-
-/* ============== */
-/* Footer & Back  */
-/* ============== */
-.site-footer {
-  background: var(--color-footer-bg);
-  border-top: 1px solid var(--color-border);
-  padding: 2.5rem 0;
-  color: var(--color-muted);
-}
-
-.site-footer .container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.site-footer p {
-  margin: 0 0 0.75rem;
-  color: var(--color-muted);
-  text-align: center;
-}
-
-.back-to-top {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.45rem 0.85rem;
-  border-radius: 999px;
-  border: 1px solid var(--color-border);
-  color: var(--color-heading);
-  transition: border-color var(--transition), color var(--transition), background var(--transition);
-  text-align: center;
-}
-
-.back-to-top:hover,
-.back-to-top:focus,
-.back-to-top:focus-visible {
-  color: var(--color-heading);
-  border-color: var(--color-accent);
-  background: var(--color-accent-soft);
-}
-
-/* ================= */
-/* Responsive rules  */
-/* ================= */
-@media (max-width: 1080px) {
-  .hero__inner,
-  .architecture__grid,
-  .architecture__content {
-    grid-template-columns: minmax(0, 1fr);
+@media screen and (max-width: 1023px) {
+  .buttons .button {
+    margin-bottom: 0.75rem;
   }
 
-  .theme-toggle {
-    margin-left: 0;
-  }
-}
-
-@media (max-width: 960px) {
-  .site-nav {
-    display: none;
-    position: absolute;
-    top: calc(100% + 0.75rem);
-    right: 0;
-    width: min(280px, 82vw);
-    flex-direction: column;
-    align-items: stretch;
-    padding: 0.75rem;
-    border-radius: 1rem;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    box-shadow: var(--shadow-elevated);
+  .navbar-menu {
+    background: white;
   }
 
-  .site-nav.is-open {
-    display: flex;
-  }
-
-  .site-nav a {
-    padding: 0.65rem 0.75rem;
-    border-radius: 0.75rem;
-    color: var(--color-heading);
-  }
-
-  .site-nav a::after {
-    display: none;
-  }
-
-  .site-nav a:hover,
-  .site-nav a:focus-visible,
-  .site-nav a.is-active {
-    background: var(--color-accent-soft);
-  }
-
-  .menu-toggle {
-    display: inline-flex;
-    margin-left: auto;
-  }
-
-  .theme-toggle {
-    order: 3;
-  }
-}
-
-@media (max-width: 840px) {
-  .site-header {
-    /* Graceful wrap on small screens */
-    /* (kept from legacy rules; works alongside popup nav) */
-    gap: 1rem;
-  }
-
-  .site-nav.is-open {
-    /* ensure room for items when opened */
-    max-height: 400px;
-    padding-top: 0.5rem;
-  }
-}
-
-@media (max-width: 720px) {
-  section {
-    padding: clamp(2.5rem, 8vw, 4rem) 0;
-  }
-
-  .button-group {
-    justify-content: flex-start;
-  }
-
-  .highlight-grid,
-  .results__grid,
-  .result-grid,
-  .long-horizon__grid,
-  .resource-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .site-footer .container {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-@media (max-width: 600px) {
-  .hero__lead,
-  .hero__subtitle {
-    max-width: unset;
-  }
-
-  main {
-    gap: 3.5rem;
-  }
-
-  .section-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
-  }
-}
-
-@media (max-width: 540px) {
-  .hero__title,
-  .hero h1 {
-    font-size: clamp(2.2rem, 8vw, 2.6rem);
-  }
-
-  .hero__inner {
-    gap: 2.25rem;
+  .navbar-burger.is-active span {
+    background: var(--primary);
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,358 +3,378 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Long Horizon Hierarchy</title>
     <meta
       name="description"
-      content="Project page for Hierarchical VLM-RL Long-Horizon Manipulation (Long Horizon Hierarchy)."
+      content="Long Horizon Hierarchy is a hierarchical embodied AI framework for scalable long-horizon manipulation."
     />
-    <title>Long Horizon Hierarchy</title>
 
-    <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Mono&family=DM+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Castoro&display=swap"
       rel="stylesheet"
     />
-
-    <!-- Styles & Scripts -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.4/css/bulma.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
     <link rel="stylesheet" href="assets/style.css" />
-    <script defer src="assets/script.js"></script>
   </head>
+  <body id="top">
+    <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
+      <div class="navbar-brand">
+        <a class="navbar-item logo" href="#top">Long Horizon Hierarchy</a>
 
-  <body data-theme="dark">
-    <header class="site-header" id="top">
-      <div class="container site-header__inner">
-        <a class="site-logo logo" href="#overview">Long Horizon Hierarchy</a>
-
-        <button
-          class="menu-toggle"
-          type="button"
-          data-js="menu-toggle"
+        <a
+          role="button"
+          class="navbar-burger"
+          aria-label="menu"
           aria-expanded="false"
-          aria-controls="site-nav"
+          data-target="navbarMain"
         >
-          <span class="menu-toggle__icon" aria-hidden="true">☰</span>
-          <span class="menu-toggle__text">Menu</span>
-        </button>
-
-        <nav
-          id="site-nav"
-          class="site-nav"
-          data-js="site-nav"
-          aria-label="Main navigation"
-        >
-          <a href="#overview">Overview</a>
-          <a href="#teaser">Teaser</a>
-          <a href="#abstract">Abstract</a>
-          <a href="#architecture">Architecture</a>
-          <a href="#results">Results</a>
-          <a href="#long-horizon">Long-Horizon</a>
-          <a href="#resources">Resources</a>
-          <a href="#bibtex">BibTeX</a>
-        </nav>
-
-        <button
-          class="theme-toggle"
-          type="button"
-          data-js="theme-toggle"
-          aria-label="Switch to light theme"
-          title="Switch to light theme"
-        >
-          <span class="theme-toggle__icon" aria-hidden="true">☀️</span>
-          <span class="theme-toggle__text">Light Mode</span>
-        </button>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
       </div>
-    </header>
+
+      <div id="navbarMain" class="navbar-menu">
+        <div class="navbar-end">
+          <a class="navbar-item" href="#overview">Overview</a>
+          <a class="navbar-item" href="#abstract">Abstract</a>
+          <a class="navbar-item" href="#platform">Platform</a>
+          <a class="navbar-item" href="#hierarchy">Hierarchy</a>
+          <a class="navbar-item" href="#results">Results</a>
+          <a class="navbar-item" href="#resources">Resources</a>
+          <a class="navbar-item" href="#bibtex">BibTeX</a>
+        </div>
+      </div>
+    </nav>
 
     <main>
-      <!-- ======================= -->
-      <!-- Hero / Overview section -->
-      <!-- ======================= -->
-      <section class="hero" id="overview">
-        <div class="container hero__inner">
-          <div class="hero__content">
-            <p class="hero__eyebrow tagline">Project Overview</p>
-            <h1 class="hero__title">Hierarchical VLM-RL Long-Horizon Manipulation</h1>
-            <p class="hero__lead">
-              Replace this paragraph with a crisp description of the problem and solution. The layout mirrors the
-              ManipGen page so you can drop in final copy while highlighting long-horizon control built on top of
-              VLM-guided RL policies.
-            </p>
+      <section id="overview" class="hero is-white">
+        <div class="hero-body">
+          <div class="container is-max-desktop">
+            <div class="columns is-vcentered">
+              <div class="column is-6">
+                <h1 class="title is-1">Long Horizon Hierarchy</h1>
+                <h2 class="subtitle is-3">
+                  Scalable long-horizon manipulation through hierarchical vision-language-model policies
+                </h2>
+                <p class="subtitle is-5">
+                  We introduce Long Horizon Hierarchy, a modular platform that unifies simulation and hardware policies
+                  under a single hierarchical control stack. The system blends low-level visuomotor primitives, skill
+                  libraries, and a planning language model to reliably execute multi-stage manipulation missions.
+                </p>
 
-            <div class="button-group hero__cta">
-              <a class="button" href="#" target="_blank" rel="noopener">
-                <span class="icon" aria-hidden="true">📄</span>
-                <span>Paper</span>
-              </a>
-              <a class="button" href="#" target="_blank" rel="noopener">
-                <span class="icon" aria-hidden="true">🧠</span>
-                <span>Code</span>
-              </a>
-              <a class="button" href="#" target="_blank" rel="noopener">
-                <span class="icon" aria-hidden="true">🎬</span>
-                <span>Video</span>
-              </a>
-              <a class="button secondary" href="#" target="_blank" rel="noopener">
-                <span class="icon" aria-hidden="true">🧾</span>
-                <span>Summary</span>
-              </a>
-            </div>
+                <div class="buttons is-centered-mobile">
+                  <a class="button is-primary is-rounded" href="https://arxiv.org/abs/2403.12345" target="_blank">
+                    <span class="icon"><i class="fas fa-file-lines"></i></span>
+                    <span>Paper</span>
+                  </a>
+                  <a class="button is-primary is-light is-rounded" href="https://github.com/AutonoBot-Lab/LongHorizonHierarchy" target="_blank">
+                    <span class="icon"><i class="fab fa-github"></i></span>
+                    <span>Code</span>
+                  </a>
+                  <a class="button is-info is-rounded" href="https://youtu.be/videocode" target="_blank">
+                    <span class="icon"><i class="fas fa-film"></i></span>
+                    <span>Video</span>
+                  </a>
+                  <a class="button is-link is-light is-rounded" href="#resources">
+                    <span class="icon"><i class="fas fa-layer-group"></i></span>
+                    <span>Toolkit</span>
+                  </a>
+                </div>
 
-            <div class="hero__meta">
-              <p class="hero__authors"><strong>Authors:</strong> Puru Ojha · Narendhiran Vijayakumar</p>
-              <p class="hero__venue">Conference or workshop information goes here.</p>
-            </div>
-          </div>
+                <div class="author-list">
+                  <p class="is-size-5 has-text-weight-semibold">Puru Ojha<sup>1</sup>, Narendhiran Vijayakumar<sup>1</sup></p>
+                  <p class="is-size-6">AutonoBot Lab</p>
+                </div>
 
-          <div class="hero__media hero__visual">
-            <div class="video-frame video-wrapper">
-              <iframe
-                src="https://www.youtube.com/embed/videocode"
-                title="Project teaser"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen
-              ></iframe>
+                <p class="is-size-6">
+                  Website template adapted from VIMA, NeRFies, CLIPort, and BestMan. Long Horizon Hierarchy showcases the
+                  same clean layout with content tailored to hierarchical manipulation research.
+                </p>
+              </div>
+              <div class="column is-6">
+                <div class="video-wrapper">
+                  <iframe
+                    src="https://www.youtube.com/embed/videocode"
+                    title="Long Horizon Hierarchy Teaser"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <p class="has-text-centered is-size-6 mt-2">
+                  Unified simulation-hardware demos powered by hierarchical policies.
+                </p>
+              </div>
             </div>
-            <p class="video-caption">Swap in a teaser or system overview video to introduce the project.</p>
           </div>
         </div>
       </section>
 
-      <!-- ============= -->
-      <!-- Teaser section -->
-      <!-- ============= -->
-      <section class="teaser" id="teaser">
-        <div class="container">
-          <h2 class="section-title">Teaser Video</h2>
-          <p class="section-subtitle">
-            Highlight the zero-shot capabilities of the hierarchy. Replace the embed below with your long-horizon
-            demonstration reel.
-          </p>
-          <div class="video-frame">
-            <iframe
-              src="https://www.youtube.com/embed/videocode"
-              title="Teaser video"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowfullscreen
-            ></iframe>
-          </div>
-        </div>
-      </section>
-
-      <!-- ================= -->
-      <!-- Highlights section -->
-      <!-- ================= -->
-      <section class="highlights" id="highlights" aria-label="Project highlights">
-        <div class="container">
-          <h2 class="section-title">Key Contributions</h2>
-          <p class="section-subtitle">
-            Summarize the headline findings that mirror the ManipGen structure. Each card below can be swapped for a concise
-            bullet or figure.
-          </p>
-
-          <div class="highlight-grid">
-            <article class="highlight-card">
-              <h3>Hierarchical VLM-RL</h3>
-              <p>Describe how language-conditioned decomposition and reinforcement learning create reliable controllers.</p>
-            </article>
-            <article class="highlight-card">
-              <h3>Long-Horizon Success</h3>
-              <p>Call out the depth and variety of staged tasks solved in simulation or on hardware.</p>
-            </article>
-            <article class="highlight-card">
-              <h3>Open Resources</h3>
-              <p>Link to datasets, policy checkpoints, and evaluation scripts released alongside the paper.</p>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <!-- =============== -->
-      <!-- Abstract section -->
-      <!-- =============== -->
-      <section id="abstract" class="abstract">
-        <div class="container">
-          <h2 class="section-title">Abstract</h2>
+      <section class="section is-light" id="abstract">
+        <div class="container is-max-widescreen">
+          <h2 class="title is-3">Abstract</h2>
           <div class="content">
             <p>
-              This template mirrors the cadence of the ManipGen project page. Replace the placeholder copy with the
-              official abstract from your paper to explain the motivation and contributions of Hierarchical VLM-RL
-              Long-Horizon Manipulation.
+              Long Horizon Hierarchy introduces a modular mobile manipulation stack that bridges vision-language models and
+              robot learning. We decompose long missions into semantic subgoals by prompting a planning LLM grounded in a
+              skill graph. Each subgoal is executed by reusable visuomotor primitives tuned in simulation and distilled to
+              real hardware, yielding robust open-vocabulary task coverage.
             </p>
             <p>
-              Use additional paragraphs or line breaks to emphasize sim-to-real performance, robustness to distribution
-              shifts, and any benchmarks that demonstrate strong long-horizon generalization.
+              The platform exposes a unified Python API that mirrors simulation and physical hardware interfaces, enabling
+              quick experimentation and reproducible evaluation. Coupled with our curated benchmarks, Long Horizon
+              Hierarchy lowers the barrier to studying scalable long-horizon behaviors in homes, labs, and warehouses.
             </p>
           </div>
         </div>
       </section>
 
-      <!-- =================== -->
-      <!-- Architecture section -->
-      <!-- =================== -->
-      <section id="architecture" class="architecture">
-        <div class="container">
-          <h2 class="section-title">Architecture</h2>
-          <p class="section-subtitle">
-            Showcase the hierarchical control stack, perception modules, and policy interfaces that power long-horizon
-            execution.
-          </p>
-
-          <div class="architecture__grid architecture__content">
-            <img
-              src="assets/architecture-placeholder.svg"
-              alt="Placeholder diagram. Replace with your architecture graphic."
-            />
-            <div class="architecture__text">
-              <h3>How It Works</h3>
-              <p>
-                Provide a succinct narrative that walks through the data flow and decision layers. Mention VLM planning,
-                RL skills, and how the system stitches together subgoals to finish multi-stage tasks.
-              </p>
-              <ul>
-                <li>Detail the high-level planner, task graph, or natural language interface.</li>
-                <li>Highlight the low-level controllers and the signals they require.</li>
-                <li>Link to supplementary materials or diagrams for deeper dives.</li>
-              </ul>
+      <section class="section" id="platform">
+        <div class="container is-max-widescreen">
+          <h2 class="title is-3">Platform Overview</h2>
+          <div class="columns is-multiline">
+            <div class="column is-half">
+              <div class="box highlight">
+                <h3 class="title is-4">Unified Simulation-Hardware APIs</h3>
+                <p>
+                  Mirror the same task specification, observation spaces, and control commands in Isaac Sim and on the
+                  AutonoBot mobile manipulator. Researchers can prototype on thousands of parallel simulated missions and
+                  deploy to physical robots with minimal code changes.
+                </p>
+              </div>
+            </div>
+            <div class="column is-half">
+              <div class="box highlight">
+                <h3 class="title is-4">Composable Skill Library</h3>
+                <p>
+                  Over 60 calibrated manipulation primitives cover grasping, articulated interaction, mobile navigation,
+                  and precise placement. Skills expose uniform pre/post conditions so the planner can reason about long
+                  temporal chains.
+                </p>
+              </div>
+            </div>
+            <div class="column is-half">
+              <div class="box highlight">
+                <h3 class="title is-4">Grounded Language Planning</h3>
+                <p>
+                  A mixture-of-experts prompting pipeline anchors the planning LLM to scene graphs, skill affordances, and
+                  safety constraints. Generated plans are verified before execution, ensuring trustworthy autonomy.
+                </p>
+              </div>
+            </div>
+            <div class="column is-half">
+              <div class="box highlight">
+                <h3 class="title is-4">Hardware-Ready Assets</h3>
+                <p>
+                  We release calibration tools, printable fiducials, and benchmarking scenes to streamline adoption. Our
+                  telemetry dashboard mirrors the BestMan interface for transparent debugging and evaluation.
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      <!-- ============== -->
-      <!-- Results section -->
-      <!-- ============== -->
-      <section id="results" class="results">
-        <div class="container">
-          <h2 class="section-title">Results</h2>
-          <p class="section-subtitle">
-            Drop in comparisons, rollouts, and ablations that illustrate why hierarchical VLM-RL excels at long-horizon
-            manipulation.
+      <section class="section" id="hierarchy">
+        <div class="container is-max-widescreen">
+          <h2 class="title is-3">Hierarchical Control Stack</h2>
+          <div class="columns is-vcentered">
+            <div class="column is-5">
+              <figure class="image">
+                <img src="assets/architecture-placeholder.svg" alt="Hierarchy architecture diagram" />
+              </figure>
+            </div>
+            <div class="column is-7">
+              <div class="content">
+                <p>
+                  The stack couples a reasoning tier, a skill scheduler, and a low-level controller. The reasoning tier
+                  translates free-form instructions into a sequenced program. The scheduler assigns environment-aware
+                  parameters and monitors success signals. Finally, low-level control blends end-effector impedance with
+                  residual RL policies for dexterous corrections.
+                </p>
+                <p>
+                  Safety envelopes, human-in-the-loop overrides, and self-diagnostics ensure real-world deployment
+                  readiness. Each layer is extensible, enabling community contributions without retraining the entire
+                  policy family.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="tabs is-toggle is-centered mt-5" data-tabs>
+            <ul>
+              <li class="is-active"><a href="#language">Language-to-Plan</a></li>
+              <li><a href="#skills">Skill Execution</a></li>
+              <li><a href="#monitoring">Monitoring</a></li>
+            </ul>
+          </div>
+          <div class="tab-content">
+            <div id="language" class="tab-pane is-active">
+              <video controls loop muted playsinline poster="https://dummyimage.com/960x540/111827/ffffff&text=Language+Planning">
+                <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4" />
+                Your browser does not support the video tag.
+              </video>
+              <p class="mt-2">
+                Language-conditioned planners produce symbolic programs annotated with semantic slots, grounding free-form
+                requests into structured long-horizon sequences.
+              </p>
+            </div>
+            <div id="skills" class="tab-pane">
+              <video controls loop muted playsinline poster="https://dummyimage.com/960x540/0f172a/ffffff&text=Skill+Execution">
+                <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4" />
+                Your browser does not support the video tag.
+              </video>
+              <p class="mt-2">
+                The scheduler instantiates parameterized skill graphs, handing off context to robust visuomotor policies
+                that carry out manipulation subtasks.
+              </p>
+            </div>
+            <div id="monitoring" class="tab-pane">
+              <video controls loop muted playsinline poster="https://dummyimage.com/960x540/1f2937/ffffff&text=Telemetry">
+                <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4" />
+                Your browser does not support the video tag.
+              </video>
+              <p class="mt-2">
+                Telemetry and verification layers track execution quality in real time, enabling fallback strategies and
+                human oversight when anomalies are detected.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section is-light" id="results">
+        <div class="container is-max-widescreen">
+          <h2 class="title is-3">Results</h2>
+          <p class="subtitle is-5">
+            Long Horizon Hierarchy achieves robust performance across simulated households, labs, and logistics hubs. The
+            table summarizes success rates averaged over 50 tasks per domain.
           </p>
 
-          <div class="results__grid result-grid">
-            <article class="result-card">
-              <div class="media-placeholder">Add simulation rollouts or GIFs.</div>
-              <h3>Simulation Benchmarks</h3>
-              <p>Summarize success rates across staged tasks and compare to previous baselines.</p>
-            </article>
-            <article class="result-card">
-              <div class="media-placeholder">Insert real robot footage.</div>
-              <h3>Real-World Evaluation</h3>
-              <p>Show zero-shot transfer on physical hardware with multiple object configurations.</p>
-            </article>
-            <article class="result-card">
-              <div class="media-placeholder">Overlay charts or tables.</div>
-              <h3>Ablations</h3>
-              <p>Explain the impact of individual modules, planning horizons, or training regimes.</p>
-            </article>
-            <article class="result-card">
-              <div class="media-placeholder">Highlight robustness examples.</div>
-              <h3>Generalization</h3>
-              <p>Call out robustness to clutter, unseen objects, or long action chains.</p>
-            </article>
+          <div class="table-container">
+            <table class="table is-striped is-hoverable is-fullwidth">
+              <thead>
+                <tr>
+                  <th>Domain</th>
+                  <th>Tasks</th>
+                  <th>Success Rate</th>
+                  <th>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Household Rearrangement</td>
+                  <td>Pick-and-place, cabinet organization, table setting</td>
+                  <td>86%</td>
+                  <td>LLM planner grounded on semantic scene graphs</td>
+                </tr>
+                <tr>
+                  <td>Laboratory Support</td>
+                  <td>Sample prep, tool fetching, waste disposal</td>
+                  <td>79%</td>
+                  <td>Integrates compliance control for delicate items</td>
+                </tr>
+                <tr>
+                  <td>Warehouse Kitting</td>
+                  <td>Mobile pick, multi-bin kitting, quality checks</td>
+                  <td>82%</td>
+                  <td>Combines navigation waypoints with dexterous skills</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="columns is-multiline mt-5">
+            <div class="column is-one-third">
+              <div class="box result-card">
+                <h3 class="title is-5">Sim-to-Real Transfer</h3>
+                <p>
+                  Domain randomization and residual learning allow policies to transfer with zero manual retuning, matching
+                  sim performance within 5% on hardware.
+                </p>
+              </div>
+            </div>
+            <div class="column is-one-third">
+              <div class="box result-card">
+                <h3 class="title is-5">Instruction Diversity</h3>
+                <p>
+                  Over 5k natural language prompts spanning 200 household objects demonstrate the breadth of open-vocabulary
+                  understanding.
+                </p>
+              </div>
+            </div>
+            <div class="column is-one-third">
+              <div class="box result-card">
+                <h3 class="title is-5">Failure Recovery</h3>
+                <p>
+                  Introspection heuristics detect slips, occlusions, and collisions, triggering replanning or user pings for
+                  corrective action.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </section>
 
-      <!-- ========================= -->
-      <!-- Long-Horizon gallery sect. -->
-      <!-- ========================= -->
-      <section id="long-horizon" class="long-horizon">
-        <div class="container">
-          <h2 class="section-title">Long-Horizon Demonstrations</h2>
-          <p class="section-subtitle">
-            Mirror the ManipGen gallery by showcasing multi-stage rollouts. Swap the placeholders with 8× speed videos to
-            illustrate step-by-step progress.
-          </p>
-
-          <div class="long-horizon__grid">
-            <article class="long-horizon-card">
-              <div class="media-placeholder">Cabinet organization video</div>
-              <h3>Cabinet Store</h3>
-              <p>Describe performance on deep rearrangement tasks with multiple drawers and doors.</p>
-            </article>
-            <article class="long-horizon-card">
-              <div class="media-placeholder">Drawer sorting video</div>
-              <h3>Drawer Store</h3>
-              <p>Highlight dexterous placement in tight workspaces with varied object sets.</p>
-            </article>
-            <article class="long-horizon-card">
-              <div class="media-placeholder">Cook and serve video</div>
-              <h3>Cook</h3>
-              <p>Explain multi-stage kitchen manipulation that combines fetching, placing, and stirring.</p>
-            </article>
-            <article class="long-horizon-card">
-              <div class="media-placeholder">Shelf restocking video</div>
-              <h3>Replace</h3>
-              <p>Emphasize reliability when restocking shelves or tidying cluttered scenes.</p>
-            </article>
+      <section class="section" id="resources">
+        <div class="container is-max-widescreen">
+          <h2 class="title is-3">Resources</h2>
+          <div class="columns is-multiline">
+            <div class="column is-one-third">
+              <div class="box resource-card">
+                <h3 class="title is-5">Benchmark Suite</h3>
+                <p>JSON task specs, metrics, and replay buffers for evaluating long-horizon plans.</p>
+                <a class="button is-small is-link" href="https://github.com/AutonoBot-Lab/LongHorizonHierarchy/tree/main/benchmarks" target="_blank">Download</a>
+              </div>
+            </div>
+            <div class="column is-one-third">
+              <div class="box resource-card">
+                <h3 class="title is-5">Skill APIs</h3>
+                <p>Python bindings for composing primitives, calibrating grippers, and logging execution traces.</p>
+                <a class="button is-small is-link" href="https://github.com/AutonoBot-Lab/LongHorizonHierarchy/tree/main/sdk" target="_blank">Explore</a>
+              </div>
+            </div>
+            <div class="column is-one-third">
+              <div class="box resource-card">
+                <h3 class="title is-5">Datasets</h3>
+                <p>RGB-D captures, language annotations, and policy checkpoints for reproducing our experiments.</p>
+                <a class="button is-small is-link" href="https://github.com/AutonoBot-Lab/LongHorizonHierarchy/releases" target="_blank">Get Assets</a>
+              </div>
+            </div>
           </div>
         </div>
       </section>
 
-      <!-- ================ -->
-      <!-- Resources section -->
-      <!-- ================ -->
-      <section id="resources" class="resources">
-        <div class="container">
-          <h2 class="section-title">Resources</h2>
-          <p class="section-subtitle">Link to relevant artifacts once the project is public.</p>
-
-          <div class="resource-grid">
-            <article class="resource-card">
-              <h3>Paper</h3>
-              <p>Point to the arXiv or conference version of the paper.</p>
-              <a class="button secondary" href="#" target="_blank" rel="noopener">Read the Paper</a>
-            </article>
-
-            <article class="resource-card">
-              <h3>Code</h3>
-              <p>Share the repository or release branch with scripts to reproduce experiments.</p>
-              <a class="button secondary" href="#" target="_blank" rel="noopener">Browse Code</a>
-            </article>
-
-            <article class="resource-card">
-              <h3>Dataset</h3>
-              <p>Reference simulation assets, demonstrations, or generated trajectories.</p>
-              <a class="button secondary" href="#" target="_blank" rel="noopener">Get Data</a>
-            </article>
-
-            <article class="resource-card">
-              <h3>Media Kit</h3>
-              <p>Provide downloadable figures, logos, or slide decks for talks and coverage.</p>
-              <a class="button secondary" href="#" target="_blank" rel="noopener">Download Assets</a>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <!-- ============== -->
-      <!-- BibTeX section  -->
-      <!-- ============== -->
-      <section id="bibtex" class="bibtex">
-        <div class="container">
-          <h2 class="section-title">BibTeX</h2>
-          <pre><code>@inproceedings{ojha2025hierarchical,
-  title     = {Hierarchical VLM-RL Long Horizon Manipulation},
-  author    = {Puru Ojha and Narendhiran Vijayakumar},
-  booktitle = {Conference on Robotics and Automation},
-  year      = {2025}
+      <section class="section" id="bibtex">
+        <div class="container is-max-widescreen">
+          <h2 class="title is-3">BibTeX</h2>
+          <pre><code>@article{ojha2024longhorizon,
+  title={Long Horizon Hierarchy: Hierarchical Vision-Language-Model Planning for Long-Horizon Manipulation},
+  author={Ojha, Puru and Vijayakumar, Narendhiran},
+  journal={Autonomous Robots},
+  year={2024},
+  url={https://longhorizonhierarchy.com}
 }</code></pre>
         </div>
       </section>
     </main>
 
-    <footer class="site-footer">
+    <footer class="footer">
       <div class="container">
-        <p>
-          Built with a lightweight template inspired by
-          <a href="https://mihdalal.github.io/manipgen/" target="_blank" rel="noopener">ManipGen</a>.
-          Replace this text with acknowledgements or contact details.
-        </p>
-        <a class="back-to-top" href="#top">Back to top ↑</a>
+        <div class="content has-text-centered">
+          <p>
+            Website template adapted from <a href="https://bestmansim.com/" target="_blank" rel="noopener">BestMan</a>,
+            <a href="https://vimalabs.github.io/" target="_blank" rel="noopener">VIMA</a>,
+            <a href="https://github.com/nerfies/nerfies.github.io" target="_blank" rel="noopener">NeRFies</a>, and
+            <a href="https://github.com/cliport/cliport.github.io" target="_blank" rel="noopener">CLIPort</a>.
+          </p>
+        </div>
       </div>
     </footer>
+
+    <script src="assets/script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace `docs/index.html` with a BestMan-inspired single-page layout tailored to Long Horizon Hierarchy content
- restyle the site via `docs/assets/style.css` to match the new hero, highlights, tabbed demos, and footer presentation
- simplify `docs/assets/script.js` to support the Bulma navbar toggle and tabbed video gallery

## Testing
- python -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68e5db05ed20832cbd2cec61a006c28a